### PR TITLE
Fixed bug in _isNew to prevent unneeded iterations after finding match

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -279,7 +279,7 @@
             this.tagList.children('.tagit-choice').each(function(i) {
                 if (that._formatStr(value) == that._formatStr(that.tagLabel(this))) {
                     isNew = false;
-                    return;
+                    return false;
                 }
             });
             return isNew;


### PR DESCRIPTION
jQuery requires you to return false to terminate the each loop.

http://api.jquery.com/jQuery.each/
