### PR TITLE
update single input before triggering onTagRemove

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -345,8 +345,6 @@
 
             tag = $(tag);
 
-            this._trigger('onTagRemoved', null, tag);
-
             if (this.options.singleField) {
                 var tags = this.assignedTags();
                 var removedTagLabel = this.tagLabel(tag);
@@ -355,6 +353,9 @@
                 });
                 this._updateSingleTagsField(tags);
             }
+
+            this._trigger('onTagRemoved', null, tag);
+
             // Animate the removal.
             if (animate) {
                 tag.fadeOut('fast').hide('blind', {direction: 'horizontal'}, 'fast', function(){


### PR DESCRIPTION
Send the onTagRemove event after the single input field has been updated so its easy to grab the new set of tags as a set.
