### PR TITLE
"x" remove button on tags attempts to remove the tag from the incorrect field.

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -293,7 +293,7 @@
         },
 
         createTag: function(value, additionalClass) {
-            that = this;
+            var that = this;
             // Automatically trims the value of leading and trailing whitespace.
             value = $.trim(value);
 


### PR DESCRIPTION
Fix variable scope. This caused a bug when multiple fields were present, and the first time the "x" was clicked to remove a tag.

As noted in issue #11, the first time you press the remove button for a tag, it doesn't work (if the field isn't focused). This is because the "that" variable in the callback erroneously refers to the last field on the page that was setup, and not the correct instance that the tag actually belongs to. So it ends up trying to remove the tag from the last input setup, where the tag may or may not exist. This is being caused by a global "that" variable being created inside createTag. Switching it to a local variable seems to fix the problem.
