### PR TITLE
Animating tag removals should be optional

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -369,7 +369,7 @@
         },
 
         removeAll: function() {
-            // Removes all tags. Takes an optional `animate` argument.
+            // Removes all tags.
             var that = this;
             this.tagList.children('.tagit-choice').each(function(index, tag) {
                 that.removeTag(tag, false);


### PR DESCRIPTION
Some people may prefer having minimal jQuery-UI packages with no effects at all, and allowing disabling the removal effects is a must in that scenarios — the `hide()` method is different in jQuery and jQuery-UI, so the removal behaviour is broken when no effects support is available.
