### PR TITLE
Copy attributes from the original element

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -123,6 +123,13 @@ For example, the user can enter `John Smith` instead of `"John Smith"`.
 
 Defaults to *false*.
 
+### animate (boolean)
+
+When animate is enabled, single tag removals will be animated with a fade out
+effect. This requires the Effects API of jQuery UI.
+
+Defaults to *true*.
+
 ### singleField (boolean)
 
 When enabled, will use a single hidden field for the form, rather than one per tag.

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -101,6 +101,17 @@
                 this._tagInput.attr('tabindex', this.options.tabIndex);
             }
 
+            // Copy the attributes from the original element into _tagInput
+            // First determine the attributes to be copied
+            var attrsNoCopy = ["type", "class", "id", "name", "style", "value"];
+            var elemAttrs = $.grep(this.element[0].attributes, function (el) {
+                return jQuery.inArray(el.name, attrsNoCopy) == -1;
+            });
+            // And then assign the attributes to the new input
+            for (var i=0; i<elemAttrs.length; i++) {
+                this._tagInput.attr(elemAttrs[i].name, elemAttrs[i].value);
+            }
+
             this.options.tagSource = this.options.tagSource || function(search, showChoices) {
                 var filter = search.term.toLowerCase();
                 var choices = $.grep(that.options.availableTags, function(element) {


### PR DESCRIPTION
This allows maintaining tooltips and other metadata that could be stored in the original element.