### PR TITLE
Bind the tagSource callback to the tag-it context

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -110,7 +110,11 @@
                 });
                 showChoices(this._subtractArray(choices, this.assignedTags()));
             };
-            this.options.tagSource = $.proxy(this.options.tagSource, this);
+
+            // Bind tagSource callback functions to this context.
+            if ($.isFunction(this.options.tagSource)) {
+                this.options.tagSource = $.proxy(this.options.tagSource, this);
+            }
 
             this.tagList
                 .addClass('tagit')


### PR DESCRIPTION
Bind the tagSource callback to the tag-it context. This allows custom callbacks to access tag-it functions, such as assignedTags(), like the default callback does.

Without this change, I couldn't figure out a clean way to access tag-it functions from a custom callback. For example, you could previously do this without problems:

``` js
$(".tags").tagit({
  tagSource: function(search, showChoices) {
    var choices = ["a", "b", "c"];
    showChoices(choices);
  }
});
```

But if you wanted to utilize `_subtractArray()` and `assignedTags()` like the default callback does, there didn't seem to be an obvious way, since the custom callback's context is in reference to the jquery autocomplete widget. With this update, you can now do:

``` js
$(".tags").tagit({
  tagSource: function(search, showChoices) {
    var choices = ["a", "b", "c"];
    showChoices(this._subtractArray(choices, this.assignedTags()));
  }
});
```

This obviously changes the context of this callback function, so it's possible this would break existing custom callbacks that were relying on `this` referencing the autocomplete ui stuff. However, I think the `search` and `showChoices` arguments to this function typically give you what you need for autocomplete purposes. But if you can think of a better solution that might work, I'm mainly interested in being able to replicate the default behavior of excluding existing tags based on the results inside a custom `tagSource` callback that does an ajax call.
