### PR TITLE
Renamed .close to .tagit-close

### DIFF
--- a/css/jquery.tagit.css
+++ b/css/jquery.tagit.css
@@ -22,7 +22,7 @@ ul.tagit li.tagit-choice a.tagit-label {
 	cursor: pointer;
 	text-decoration: none;
 }
-ul.tagit li.tagit-choice .close {
+ul.tagit li.tagit-choice .tagit-close {
 	cursor: pointer;
     position: absolute;
     right: .1em;
@@ -31,7 +31,7 @@ ul.tagit li.tagit-choice .close {
 }
 
 /* used for some custom themes that don't need image icons */
-ul.tagit li.tagit-choice .close .text-icon {
+ul.tagit li.tagit-choice .tagit-close .text-icon {
     display: none;
 }
 

--- a/css/tagit.ui-zendesk.css
+++ b/css/tagit.ui-zendesk.css
@@ -20,16 +20,16 @@ ul.tagit li.tagit-choice {
     color: #555;
     font-weight: normal;
 }
-ul.tagit li.tagit-choice a.close {
+ul.tagit li.tagit-choice a.tagit-close {
     text-decoration: none;
 }
-ul.tagit li.tagit-choice .close {
+ul.tagit li.tagit-choice .tagit-close {
     right: .4em;
 }
 ul.tagit li.tagit-choice .ui-icon {
     display: none;
 }
-ul.tagit li.tagit-choice .close .text-icon {
+ul.tagit li.tagit-choice .tagit-close .text-icon {
     display: inline;
     font-family: arial, sans-serif;
     font-size: 16px;
@@ -41,7 +41,7 @@ ul.tagit li.tagit-choice:hover, ul.tagit li.tagit-choice.remove {
     border-color: #6d95e0;
 }
 ul.tagit li.tagit-choice a.tagLabel:hover,
-ul.tagit li.tagit-choice a.close .text-icon:hover {
+ul.tagit li.tagit-choice a.tagit-close .text-icon:hover {
     color: #222;
 }
 ul.tagit input[type="text"] {

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -321,7 +321,7 @@
             var removeTagIcon = $('<span></span>')
                 .addClass('ui-icon ui-icon-close');
             var removeTag = $('<a><span class="text-icon">\xd7</span></a>') // \xd7 is an X
-                .addClass('close')
+                .addClass('tagit-close')
                 .append(removeTagIcon)
                 .click(function(e) {
                     // Removes a tag when the little 'x' is clicked.


### PR DESCRIPTION
Due to conflict with `facebox` or any other plugin which uses `a.close` for styling a close button.
