### PR TITLE
Broken link in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Tag-it was originally inspired by the "tag suggestion" form field in ZenDesk.com
 
 ![Screenshot](http://aehlke.github.com/tag-it/screenshot.png)
 
-Check the [examples.html](https://github.com/aehlke/tag-it/blob/master/examples.html) for several demos.
+Check the [examples.html](http://aehlke.github.com/tag-it/examples.html) for several demos.
 
 
 ## Usage


### PR DESCRIPTION
Points to aehlke.github.com/tag-it/example.html but the only valid link I could find was github.com/aehlke/tag-it/blob/master/examples.html

At some point it must have been renamed from example.html to examples.html
