### PR TITLE
adding placeholder text

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -147,6 +147,11 @@ Optionally set a *tabindex* attribute on the `input` that gets created for tag-i
 
 Defaults to *null*
 
+### placeholderText (String)
+Optionally set a *placeholder* attribute on the `input` that gets created for tag-it user input.
+
+Defaults to *null*
+
 
 ## Events
 

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -34,6 +34,7 @@
             tagSource         : null,
             removeConfirmation: false,
             caseSensitive     : true,
+            placeholderText   : null,
 
             // When enabled, quotes are not neccesary
             // for inputting multi-word tags.
@@ -99,6 +100,9 @@
             this._tagInput = $('<input type="text" />').addClass('ui-widget-content');
             if (this.options.tabIndex) {
                 this._tagInput.attr('tabindex', this.options.tabIndex);
+            }
+            if (this.options.placeholderText) {
+                this._tagInput.attr('placeholder', this.options.placeholderText);
             }
 
             this.options.tagSource = this.options.tagSource || function(search, showChoices) {


### PR DESCRIPTION
Hi,

I was implementing tag-it in a project and wanted to have a way to add placeholder text in the automatically created input element (e.g. "type some tags here").

I added an option for that so I could do it cleanly, thought I'd send it over in case you thought this patch might be useful.

Ben
