### PR TITLE
Added onTagExists callback

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -188,6 +188,16 @@ The function receives the click event and the tag as parameters.
         }
     });
 
+### onTagExists (function, Callback)
+
+Can be used to add custom behaviour when an attempt is made to add a Tag that already exists.
+The function receives an empty event, and the existing tag as parameters.
+
+    $('#myTags').tagit({
+        onTagExists: function(event, tag) {
+            // do something special
+        }
+    });
 
 ## Methods
 

--- a/examples.html
+++ b/examples.html
@@ -76,6 +76,10 @@
                 onTagClicked: function(evt, tag) {
                     console.log(tag);
                     alert('This tag was clicked: ' + eventTags.tagit('tagLabel', tag));
+                },
+                onTagExists: function(evt, tag) {
+                    console.log("existing", tag);
+                    $(tag).effect('highlight');
                 }
             }).tagit('option', 'onTagAdded', function(evt, tag) {
                 // Add this callbackafter we initialize the widget,

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -76,7 +76,8 @@
             // Event callbacks.
             onTagAdded  : null,
             onTagRemoved: null,
-            onTagClicked: null
+            onTagClicked: null,
+            onTagExists : null
         },
 
 
@@ -285,16 +286,16 @@
             }
         },
 
-        _isNew: function(value) {
+        _exists: function(value) {
             var that = this;
-            var isNew = true;
-            this.tagList.children('.tagit-choice').each(function(i) {
+            var exists = false;
+            this.tagList.find('.tagit-choice').each(function(i) {
                 if (that._formatStr(value) == that._formatStr(that.tagLabel(this))) {
-                    isNew = false;
+                    exists = this;
                     return false;
                 }
             });
-            return isNew;
+            return exists;
         },
 
         _formatStr: function(str) {
@@ -309,7 +310,12 @@
             // Automatically trims the value of leading and trailing whitespace.
             value = $.trim(value);
 
-            if (!this._isNew(value) || value === '') {
+            if (value === '')
+                return false;
+
+            var existing_tag = this._exists(value);
+            if (existing_tag) {
+                this._trigger('onTagExists', null, existing_tag);
                 return false;
             }
 


### PR DESCRIPTION
Great plugin, thanks! We believe the best way to pay for open source is to contribute back.

We found that we wanted to give our users feedback when they tried to add a tag that already existed, but there was no callback for this purpuse. This pull request adds that callback.

It works like the other callbacks, and gives you access to the existing tag that caused the collision. This makes it easy to add an effect to the existing tag.

We repurposed the _isNew function, and renamed it _exists. Instead of returning true/false, it returns the existing tag or false if no such tag was found.

createTag previously returned false if the tag exists or is the empty string. This is where we added the trigger for onTagExists, but the empty string should not trigger onTagExists, so this conditional has been broken up into two conditionals. This has the added benefit of avoiding an unnecessary loop over existing tags for the empty string.

Finally, _exists now checks all .tagit-choice decendants, not just immediate children of tagList. The reason is that some jQuery effects will insert a DIV around the animated element, which interferes with the children lookup. It was possible to insert duplicate tags during e.g. a shake animation.

We hope this callback will be useful for other tag-it users. We've added some documentation to the readme, and an example to examples.html.
