### PR TITLE
Allow passing of data attributes with tags

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -52,7 +52,7 @@
             //
             // The easiest way to use singleField is to just instantiate tag-it
             // on an INPUT element, in which case singleField is automatically
-            // set to true, and singleFieldNode is set to that element. This 
+            // set to true, and singleFieldNode is set to that element. This
             // way, you don't need to fiddle with these options.
             singleField: false,
 
@@ -64,7 +64,7 @@
             // delimited by singleFieldDelimiter.
             //
             // If this is not set, we create an input node for it,
-            // with the name given in settings.fieldName, 
+            // with the name given in settings.fieldName,
             // ignoring settings.itemName.
             singleFieldNode: null,
 
@@ -140,7 +140,7 @@
             // Add existing tags from the list, if any.
             this.tagList.children('li').each(function() {
                 if (!$(this).hasClass('tagit-new')) {
-                    that.createTag($(this).html(), $(this).attr('class'));
+                    that.createTag($(this).html(), $(this).attr('class'), $(this).data());
                     $(this).remove();
                 }
             });
@@ -211,7 +211,7 @@
                     // Create a tag when the element loses focus (unless it's empty).
                     that.createTag(that._cleanedInput());
                 });
-                
+
 
             // Autocomplete.
             if (this.options.availableTags || this.options.tagSource) {
@@ -227,7 +227,7 @@
                         if (that._tagInput.val() === '') {
                             that.removeTag(that._lastTag(), false);
                         }
-                        that.createTag(ui.item.value);
+                        that.createTag(ui.item.value, null, ui.item);
                         // Preventing the tag input to be updated with the chosen value.
                         return false;
                     }
@@ -304,7 +304,7 @@
             return $.trim(str.toLowerCase());
         },
 
-        createTag: function(value, additionalClass) {
+        createTag: function(value, additionalClass, data) {
             var that = this;
             // Automatically trims the value of leading and trailing whitespace.
             value = $.trim(value);
@@ -320,6 +320,10 @@
                 .addClass('tagit-choice ui-widget-content ui-state-default ui-corner-all')
                 .addClass(additionalClass)
                 .append(label);
+
+            if (data) {
+                tag.data("tagit", data)
+            }
 
             // Button for removing the tag.
             var removeTagIcon = $('<span></span>')
@@ -351,7 +355,7 @@
             // insert tag
             this._tagInput.parent().before(tag);
         },
-        
+
         removeTag: function(tag, animate) {
             animate = animate || this.options.animate;
 


### PR DESCRIPTION
This allows data attributes added to li's in the markup as well as attributes
added to autocomplete entries to be added to tags.

Example use cases are when the tag name itself is not the unique id needed for
persistence or when you need to have a url for each tag that can be triggered on
click.
