### PR TITLE
Allow submit form pressing ENTER.

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -200,7 +200,6 @@
                             )
                         )
                     ) {
-                        event.preventDefault();
                         that.createTag(that._cleanedInput());
 
                         // The autocomplete doesn't close automatically when TAB is pressed.


### PR DESCRIPTION
On "preventing default" we are breaking normal expectation of user. Typing ENTER on a input[text] should validate and submit information.
