### PR TITLE
Fixed the order of onTagRemoved and return false when closing a tag

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -330,6 +330,7 @@
                 .click(function(e) {
                     // Removes a tag when the little 'x' is clicked.
                     that.removeTag(tag);
+                    return false;
                 });
             tag.append(removeTag);
 


### PR DESCRIPTION
onTagRemoved and onTagAdded were different in how they worked. One was working after the event while the other was working before. Now they are both consistant. 

Also I returned false after closing a tag so you don't get re-routed elsewhere. 
