### PR TITLE
Added new option: allowNotDefinedTags

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -40,6 +40,9 @@
             // for inputting multi-word tags.
             allowSpaces: false,
 
+            // When disabled, tag-it only allows tags in availableTags
+            allowNotDefinedTags: true,
+
             // Whether to animate tag removals or not.
             animate: true,
 
@@ -309,7 +312,7 @@
             // Automatically trims the value of leading and trailing whitespace.
             value = $.trim(value);
 
-            if (!this._isNew(value) || value === '') {
+            if (!this._isNew(value) || value === '' || (!this.options.allowNotDefinedTags && $.inArray(value, this.options.availableTags)==-1)) {
                 return false;
             }
 


### PR DESCRIPTION
I've added the option allowNotDefinedTags (default value: true) to make easier restricted tagging (for example, when it's a must use previously existing tags)
