### PR TITLE
I don't think you must to trigger onTagAdded on initialization

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -79,7 +79,7 @@
             onTagClicked: null
         },
 
-
+        init: true,
         _create: function() {
             // for handling static scoping inside callbacks
             var that = this;
@@ -233,6 +233,7 @@
                     }
                 });
             }
+            this.init=false;
         },
 
         _cleanedInput: function() {
@@ -343,7 +344,9 @@
                 tag.append('<input type="hidden" style="display:none;" value="' + escapedValue + '" name="' + this.options.itemName + '[' + this.options.fieldName + '][]" />');
             }
 
-            this._trigger('onTagAdded', null, tag);
+            if (!this.init) {
+                this._trigger('onTagAdded', null, tag);
+            }
 
             // Cleaning the input.
             this._tagInput.val('');


### PR DESCRIPTION
When I create the widget it create tags and it triggers the onTagAdded event.
I use this event to send an update ajax request to the server so it is a problem for me if it trigger onTagAdded on initialization.
Maybe we need a different callback for the init tag creation.
