### PR TITLE
Fix issue 83 onTagAdded event fired twice

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -209,9 +209,10 @@
                     }
                 }).blur(function(e){
                     // Create a tag when the element loses focus (unless it's empty).
-                    that.createTag(that._cleanedInput());
+                    if(0 === that.options.availableTags.length && null === that.options.tagSource){// Only when not using autocomplete
+                        that.createTag(that._cleanedInput());
+                    }
                 });
-                
 
             // Autocomplete.
             if (this.options.availableTags || this.options.tagSource) {


### PR DESCRIPTION
This patch prevents onTagAdded being fired twice when using autocomplete.
