### PR TITLE
option singleFieldNode should be a selector

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -157,7 +157,9 @@
                     });
                 } else {
                     // Create our single field input after our list.
-                    this.options.singleFieldNode = this.tagList.after('<input type="hidden" style="display:none;" value="" name="' + this.options.fieldName + '" />');
+                    this.tagList.after('<input type="hidden" style="display:none;" value="" id="' + this.options.fieldName + '" name="' + this.options.fieldName + '" />');
+                    // Set the selector
+                    this.options.singleFieldNode = '#' + this.options.fieldName;
                 }
             }
 


### PR DESCRIPTION
When the option singleField is set, and tag-it is implemented on a list, a single hidden field is added to the dom. However, singleFieldNode is being set to the list dom object returned by the jQuery after function. It needs to be set to the selector of the hidden field in order to work properly. This patch fixes that problem.
