### PR TITLE
escaped html-entities when initialized from existing ul (with e.g. &amp; present)

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -140,7 +140,7 @@
             // Add existing tags from the list, if any.
             this.tagList.children('li').each(function() {
                 if (!$(this).hasClass('tagit-new')) {
-                    that.createTag($(this).html(), $(this).attr('class'));
+                    that.createTag($(this).text(), $(this).attr('class'));
                     $(this).remove();
                 }
             });


### PR DESCRIPTION
html-entities (e.g. &amp;) within ul-elements were copied 1:1 by .html() during creation of new tag-labels

issue already noticed in #48, #64, #101
