### PR TITLE
Remove the need for fieldName

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -29,7 +29,7 @@
     $.widget('ui.tagit', {
         options: {
             itemName          : 'item',
-            fieldName         : 'tags',
+            fieldName         : null,
             availableTags     : [],
             tagSource         : null,
             removeConfirmation: false,
@@ -339,8 +339,9 @@
                 tags.push(value);
                 this._updateSingleTagsField(tags);
             } else {
-                var escapedValue = label.html();
-                tag.append('<input type="hidden" style="display:none;" value="' + escapedValue + '" name="' + this.options.itemName + '[' + this.options.fieldName + '][]" />');
+                var escapedValue = label.html(),
+                    field = (this.options.fieldName) ? '[' + this.options.fieldName + ']' : '';
+                tag.append('<input type="hidden" style="display:none;" value="' + escapedValue + '" name="' + this.options.itemName + field + '[]" />');
             }
 
             this._trigger('onTagAdded', null, tag);


### PR DESCRIPTION
Currently we're using a set REST API and we want a flat tag list..

``` javascript
tags = ['Cat', 'Dog', etc.];
```

However with this plugin you can only do...

``` javascript
tags = {
    fieldName : ['Cat', 'Dog', etc.]
};
```
