### PR TITLE
Allow animate option to be false. 

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -353,7 +353,7 @@
         },
         
         removeTag: function(tag, animate) {
-            animate = animate || this.options.animate;
+            animate = typeof animate === "undefined" ? this.options.animate : animate;
 
             tag = $(tag);
 


### PR DESCRIPTION
removeAll method passes 'false' for animate option. However, 
that option is never picked up, and the default one from this.options is 
always used. 
