### PR TITLE
Allow duplicates and match against regex pattern

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -40,6 +40,9 @@
             // for inputting multi-word tags.
             allowSpaces: false,
 
+            // When enabled, allows duplicate entries
+            allowDuplicates   : false,
+
             // Whether to animate tag removals or not.
             animate: true,
 
@@ -72,6 +75,10 @@
             // created for tag-it.
             tabIndex: null,
 
+            // Optionally add a regex pattern that valid entries have to match
+            // Add a pattern like this one which will allow only numbers up to 999:
+            // pattern: /^\d{1,3}$/
+            pattern: null,
 
             // Event callbacks.
             onTagAdded  : null,
@@ -308,8 +315,8 @@
             var that = this;
             // Automatically trims the value of leading and trailing whitespace.
             value = $.trim(value);
-
-            if (!this._isNew(value) || value === '') {
+            
+            if (!(this.options.allowDuplicates || this._isNew(value)) || value === '' || (this.options.pattern && !value.match(this.options.pattern))) {
                 return false;
             }
 


### PR DESCRIPTION
Hi, I added two options that I need for my own project. Feel free to merge them back into your own branch.
- allowDuplicates option to allow duplicates (not useful for tags, but useful in some other use cases)
- pattern option to allow only entries matching that pattern, e.g. only numbers
