### PR TITLE
Optional Tag Label

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -176,13 +176,12 @@
             this.tagInput
                 .keydown(function(event) {
                     // Needed to allow the autocomplete menu to open when user hits the down arrow
-                    if (event.which !== $.ui.keyCode.DOWN)
-                        DOWN_PRESSED = false;
-
+                    DOWN_PRESSED = false;
+                    
                     // Capture DOWN key to begin search
                     if (event.which === $.ui.keyCode.DOWN && that.tagInput.val() === '') {
                         DOWN_PRESSED = true;
-                        that.tagInput.autocomplete( "search", "" );
+                        return;
                     }
 
                     // Clear the input and close the autocomplete on ESCAPE


### PR DESCRIPTION
I originally added the ability to set the tag label to either the label or value because I needed the feature, but figured it would be a great feature to have.

You can now use the 'tagLabel' option to set it to either 'label' or 'value' as so:

$('#input').tagit({
       tagLabel : 'label'
});

The tag data-value is always set to 'value' as well.  

I  also added the minLength and autoFocus options into tag-it, which are just autocomplete options I found useful.

I  also added the ability for user to press down arrow to begin search.

If you like some but not all of these changes, just let me know and I'll break them up and resubmit the pull request. 
