### PR TITLE
Fixes logic flaw with tagLimit

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -60,7 +60,7 @@
             //
             // The easiest way to use singleField is to just instantiate tag-it
             // on an INPUT element, in which case singleField is automatically
-            // set to true, and singleFieldNode is set to that element. This
+            // set to true, and singleFieldNode is set to that element. This 
             // way, you don't need to fiddle with these options.
             singleField: false,
 
@@ -235,7 +235,7 @@
 
                     // Comma/Space/Enter are all valid delimiters for new tags,
                     // except when there is an open quote or if setting allowSpaces = true.
-                    // Tab will also create a tag, unless the tag input is empty,
+                    // Tab will also create a tag, unless the tag input is empty, 
                     // in which case it isn't caught.
                     if (
                         event.which === $.ui.keyCode.COMMA ||


### PR DESCRIPTION
If you specify tagLimit, tag-it stops working. This is because of an error in the logic that compares the number of tags against the limit.
