### PR TITLE
"onTagRemoved" not called at correct time if animating

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -500,16 +500,18 @@
                 tag.addClass('removed'); // Excludes this tag from _tags.
                 var hide_args = this._effectExists('blind') ? ['blind', {direction: 'horizontal'}, 'fast'] : ['fast'];
 
+                var thisTag = this;
                 hide_args.push(function() {
                     tag.remove();
+                    thisTag._trigger('afterTagRemoved', null, {tag: tag, tagLabel: thisTag.tagLabel(tag)});
                 });
 
                 tag.fadeOut('fast').hide.apply(tag, hide_args).dequeue();
             } else {
                 tag.remove();
+                this._trigger('afterTagRemoved', null, {tag: tag, tagLabel: this.tagLabel(tag)});
             }
 
-            this._trigger('afterTagRemoved', null, {tag: tag, tagLabel: this.tagLabel(tag)});
         },
 
         removeTagByLabel: function(tagLabel, animate) {


### PR DESCRIPTION
The "onTagRemoved" event occurs just before the tag is actually removed, if animation is enabled.  This makes it so I'm unable to correctly count the number of tags that the user has entered, which is useful if I want the suggestions to change depending on what's already been entered.
