### PR TITLE
Fix Tag-it preventing selection of auto-complete values via keyboard

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -262,11 +262,11 @@
                             event.preventDefault();
                         }
 
-                        that.createTag(that._cleanedInput());
+                        // Autocomplete will create its own tag from a selection and close automatically.
+                        if (!that.tagInput.data('autocomplete-open')) {
+                            that.createTag(that._cleanedInput());
+                        }
 
-                        // The autocomplete doesn't close automatically when TAB is pressed.
-                        // So let's ensure that it closes.
-                        that.tagInput.autocomplete('close');
                     }
                 }).blur(function(e){
                     // Create a tag when the element loses focus.


### PR DESCRIPTION
If I configure a page with an standard `<input>` tag, the latest version of Tag-it and appropriate dependencies, if I try and do:

```
$('input[name="search_term"]').tagit({
    allowSpaces: true,
    caseSensitive: false,
    singleField: true,
    autocomplete: 
        {source: ['one', 'two', 'three'], //typically I use an external source here
        delay: 0,
        autoFocus: true}
});
```

then Tag-it works, except for when I'm attempting to select an item out of the autocomplete results via hitting tab or enter on the keyboard.  

`autoFocus` is true, so the first item in the results is automatically selected when the autocomplete entries appear.  However, after entering some text (eg `thr`), and hitting the Enter or Tab key, a tag is created with the `thr` text, rather than `three`, which was the entry selected within the autocomplete menu.

This pull request ensures that during the `keydown` event, that a tag is only created if autocomplete isn't present/open, as the `select` handler for the autocomplete will handle creating the tag for us later.  Previously, the `keydown` event was prematurely creating a tag from the half-complete input & closing the autocomplete too early.
