### PR TITLE
Option to allow new tag creation when autocomplete up

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -28,13 +28,14 @@
 
     $.widget('ui.tagit', {
         options: {
-            allowDuplicates   : false,
-            caseSensitive     : true,
-            fieldName         : 'tags',
-            placeholderText   : null,   // Sets `placeholder` attr on input field.
-            readOnly          : false,  // Disables editing.
-            removeConfirmation: false,  // Require confirmation to remove tags.
-            tagLimit          : null,   // Max number of tags allowed (null for unlimited).
+            allowDuplicates    : false,
+            caseSensitive      : true,
+            fieldName          : 'tags',
+            placeholderText    : null,   // Sets `placeholder` attr on input field.
+            readOnly           : false,  // Disables editing.
+            removeConfirmation : false,  // Require confirmation to remove tags.
+            tagLimit           : null,   // Max number of tags allowed (null for unlimited).
+            enforceAutocomplete: true,   // Do not allow creation of tags when autocomplete is up
 
             // Used for autocomplete, unless you override `autocomplete.source`.
             availableTags     : [],
@@ -266,7 +267,8 @@
                         }
 
                         // Autocomplete will create its own tag from a selection and close automatically.
-                        if (!that.tagInput.data('autocomplete-open')) {
+                        // Prevent creation of new tags with autocomplete up via enforceAutocomplete option
+                        if (!(that.options.enforceAutocomplete && that.tagInput.data('autocomplete-open'))) {
                             that.createTag(that._cleanedInput());
                         }
                     }


### PR DESCRIPTION
Normally you can create tags with impunity, but when autocomplete is up, you can only create tags by selecting from the autocomplete list.  Even trying to create a new tag that exists in the list will not work.

This behavior does not make sense to me, but it is the default behavior.  I decided to include an option that would allow you to override this behavior (i.e. still create a new tag when autocomplete is up), defaulting to the old behavior.
