### PR TITLE
Allow creation of tags when autocomplete menu is open

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -266,7 +266,8 @@
                         }
 
                         // Autocomplete will create its own tag from a selection and close automatically.
-                        if (!that.tagInput.data('autocomplete-open')) {
+                        if (!(that.options.autocomplete.autoFocus && that.tagInput.data('autocomplete-open'))) {
+                            that.tagInput.autocomplete('close');
                             that.createTag(that._cleanedInput());
                         }
                     }


### PR DESCRIPTION
Commit d416408c1d43c783f7145abb244957da1ba31f44 causes a regression where one is unable to create tags when the autocomplete menu is open. That commit really only needs to apply when autoFocus is enabled, so this commit limits it to that situation. Also close the autocomplete menu when creating a tag.
