### PR TITLE
- [removeTag] fix an issue preventing spaced tags to be deleted.

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -368,16 +368,9 @@
             // Returns an array of tag string values
             var that = this;
             var tags = [];
-            if (this.options.singleField) {
-                tags = $(this.options.singleFieldNode).val().split(this.options.singleFieldDelimiter);
-                if (tags[0] === '') {
-                    tags = [];
-                }
-            } else {
-                this._tags().each(function() {
-                    tags.push(that.tagLabel(this));
-                });
-            }
+            this._tags().each(function() {
+                tags.push(that.tagLabel(this));
+            });
             return tags;
         },
 


### PR DESCRIPTION
When inputField == true and inputFieldDelimiter == ' ' and allowSpaces == true - the optimized version of tags(), was errnously considering each word as separate tag, which is nor necessary true. The result was that tags were deleted visually, but not from the field, because this passage in removeTag() was filtering nothing:

```
                var removedTagLabel = this.tagLabel(tag);
                tags = $.grep(tags, function(el){
                    return el != removedTagLabel;
                });
```

Changing the assignedTag() function fixed the issue.
