### PR TITLE
Validate tags against a regexp

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -59,6 +59,14 @@
             });
 
             //-------------------------------
+            // Single field with validation
+            //-------------------------------
+            // validateRegexp only allows a given pattern (only numbers)
+            $('#validateRegexp').tagit({
+                pattern: /^\d+$/
+            });
+
+            //-------------------------------
             // Preloading data in markup
             //-------------------------------
             $('#myULTags').tagit({
@@ -186,6 +194,15 @@
                 If you instantiate Tag-it on an INPUT element, it will default to being singleField, with that INPUT element as the singleFieldNode. This is the simplest way to have a gracefully-degrading tag widget.
             </p>
             <input name="tags" id="singleFieldTags2" value="Apple, Orange">
+        </form>
+
+        <hr>
+        <h3><a name="graceful-degredation"></a>RegExp validation</h3>
+        <form>
+            <p>
+                You can restrict acceptable inputs using a regular expression.
+            </p>
+            <input name="tags" id="validateRegexp" value="123, 456">
         </form>
 
         <hr>

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -237,10 +237,19 @@
                         that._lastTag().removeClass('remove ui-state-highlight');
                     }
 
-                    var text = that._cleanedInput() + String.fromCharCode(event.keyCode);
-                    
-                    if (that.options.pattern && !that.options.test(text)) {
-                        return false;
+                    // Validate input pattern
+                    var ignorableKeyCodes = [
+                        $.ui.keyCode.BACKSPACE,
+                        $.ui.keyCode.COMMA,
+                        $.ui.keyCode.ENTER,
+                        $.ui.keyCode.TAB,
+                    ];
+
+                    if ($.inArray(event.which, ignorableKeyCodes) == -1) {
+                        var text = that._cleanedInput() + String.fromCharCode(event.keyCode);
+                        if (that.options.pattern && !that.options.pattern.test(text)) {
+                            return false;
+                        }
                     }
 
                     // Comma/Space/Enter are all valid delimiters for new tags,


### PR DESCRIPTION
This is a simple proposal to validate tags against a regular expression as they are typed by the user.
It includes an example for a numbers-only tag (/^\d+$/).
