### PR TITLE
Fix hover reflow

### DIFF
--- a/css/tagit.ui-zendesk.css
+++ b/css/tagit.ui-zendesk.css
@@ -1,4 +1,3 @@
-
 /* Optional scoped theme for tag-it which mimics the zendesk widget. */
 
 
@@ -79,6 +78,7 @@ ul.tagit input[type="text"] {
     text-decoration:none;
     display:block;
     padding:.2em .4em;
+	border: 1px solid white;
     line-height:1.5;
     zoom:1;
 }


### PR DESCRIPTION
The list-item hover effect adds a border to the list item. The border causes the element to change width, and the longest text element will be forced to line-break. Also, everything below the element is shifted one pixel on hover. This patch fixes the issue.
