### PR TITLE
Minimal label/value support

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -136,11 +136,11 @@
             //-------------------------------
             // Label/value pairs
             //-------------------------------
-            var sampleTags2 = [{label:'c++', value:0}, {label:'java', value:1}, {label:'php', value:2}, {label:'coldfusion', value:3}, {label:'javascript', value:4}, {label:'asp', value:5}, {label:'ruby', value:6}, {label:'python', value:7}, {label:'c', value:8}, {label:'scala', value:9}, {label:'groovy', value:10}, {label:'haskell', value:11}, {label:'perl', value:12}, {label:'erlang', value:13}, {label:'apl', value:14}, {label:'cobol', value:15}, {label:'go', value:16}, {label:'lua', value:17}];
+            // Not the use of tag_id rather than label
+            var sampleTags2 = [{label:'c++', tag_id:0}, {label:'java', tag_id:1}, {label:'php', tag_id:2}, {label:'coldfusion', tag_id:3}, {label:'javascript', tag_id:4}, {label:'asp', tag_id:5}, {label:'ruby', tag_id:6}, {label:'python', tag_id:7}, {label:'c', tag_id:8}, {label:'scala', tag_id:9}, {label:'groovy', tag_id:10}, {label:'haskell', tag_id:11}, {label:'perl', tag_id:12}, {label:'erlang', tag_id:13}, {label:'apl', tag_id:14}, {label:'cobol', tag_id:15}, {label:'go', tag_id:16}, {label:'lua', tag_id:17}];
 
             $('#labelValuePairs').tagit({
-                availableTags: sampleTags2,
-                autocomplete: {}
+                autocomplete: {source: sampleTags2}
             });
             
         });
@@ -273,18 +273,20 @@
         <form>
             <p>
                 When you want label/value pairs you can set your data in the form of:<br />
-                [{label: "php", value: 2}, {label: "go", value:16}]
+                [{label: "php", tag_id: 2}, {label: "go", tag_id:16}]
             </p>
             <p>
-                This will display the "label" to users but send the "value" to the hidden form field.
+                This will display the "label" to users but send the "tag_id" to the hidden form field.
             </p>
             <p>
                 <strong>CAVEATS:</strong>
             </p>
             <ul>
-                <li>You cannot currently pre-fill label-value pairs</li>
-                <li>Label-value pairs only work with autocomplete</li>
-                <li>You cannot use label-value pairs with a single input field</li>
+                <li>You can only provide this data to autocomplete.source, not availableTags</li>
+                <li>You cannot currently pre-fill label-tag_id pairs</li>
+                <li>Label-tag_id pairs only work with autocomplete</li>
+                <li>You cannot use label-tag_id pairs with a single input field</li>
+                <li>Does not properly prevent duplicates</li>
             </ul>
             <ul id="labelValuePairs">
             </ul>

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -283,15 +283,12 @@
             if (this.options.availableTags || this.options.tagSource || this.options.autocomplete.source) {
                 var autocompleteOptions = {
                     select: function(event, ui) {
-                        that.createTag(ui.item.value2, ui.item.label);
+                        if (ui.item.tag_id === undefined) {
+                            ui.item.tag_id = ui.item.label;
+                        }
+                        that.createTag(ui.item.tag_id, ui.item.label);
                         // Preventing the tag input to be updated with the chosen value.
                         return false;
-                    },
-                    focus: function(event, ui) {
-                        // By default Autocomplete returns 'value' if present
-                        // we can change the name of value to avoid this behavior
-                        ui.item.value2 = ui.item.value;
-                        ui.item.value = ui.item.label;
                     }
                 };
                 $.extend(autocompleteOptions, this.options.autocomplete);


### PR DESCRIPTION
Here's a possible solution to the label/value request that comes up frequently (eg: https://github.com/aehlke/tag-it/issues/266, https://github.com/aehlke/tag-it/issues/160, https://github.com/aehlke/tag-it/pull/80).

This works well with a few caveats that could be dealt with in future:
- You can only provide this data to autocomplete.source, not availableTags
- You cannot currently pre-fill label-tag_id pairs
- Label-tag_id pairs only work with autocomplete
- You cannot use label-tag_id pairs with a single input field
- Does not properly prevent duplicates

I think this is a good start to the solution, the one proposed in https://github.com/aehlke/tag-it/pull/80 is from old code so may not be ideal for merging.
