### PR TITLE
Internationalization fix for comma

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -235,13 +235,14 @@
                     } else if (that.options.removeConfirmation) {
                         that._lastTag().removeClass('remove ui-state-highlight');
                     }
-
+                })
+                .keypress(function(event){
                     // Comma/Space/Enter are all valid delimiters for new tags,
                     // except when there is an open quote or if setting allowSpaces = true.
                     // Tab will also create a tag, unless the tag input is empty,
                     // in which case it isn't caught.
                     if (
-                        (event.which === $.ui.keyCode.COMMA && event.shiftKey === false) ||
+                        (event.charCode > 0 && String.fromCharCode(event.charCode) == ',') ||
                         event.which === $.ui.keyCode.ENTER ||
                         (
                             event.which == $.ui.keyCode.TAB &&
@@ -271,7 +272,9 @@
                             that.createTag(that._cleanedInput());
                         }
                     }
-                }).blur(function(e){
+
+                })
+                .blur(function(e){
                     // Create a tag when the element loses focus.
                     // If autocomplete is enabled and suggestion was clicked, don't add it.
                     if (!that.tagInput.data('autocomplete-open')) {


### PR DESCRIPTION
It's wrong to rely on keyCode of keydown event handler to catch the comma char, as keydown/keyup events firing keyCode independently of keyboard layout.

Example: i want to input a word in my language, but key is situated right over english comma, but its not comma. Result - createTag triggered with incomplete word.

I added another 'keypress' event handler to catch charCode of symbolic keys and to compare it with comma char. Also it must fix double-quotes bug, because keydown event is firing before input value is changed and final quote would not fire 'createTag' until some next key triggers it.