### PR TITLE
Tag doesn't create on blur when autcomplete list is open

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -274,7 +274,7 @@
                 }).blur(function(e){
                     // Create a tag when the element loses focus.
                     // If autocomplete is enabled and suggestion was clicked, don't add it.
-                    if (!that.tagInput.data('autocomplete-open')) {
+                    if (!that.tagInput.autocomplete('widget').find(".ui-menu-item a").hasClass("ui-state-focus")) {
                         that.createTag(that._cleanedInput());
                     }
                 });


### PR DESCRIPTION
When the autocomplete list is open, any tag creation is suppressed. The
implementation suggests that it was added to prevent accidental addition of
tags when user is searching through the suggestions and focus is lost from the
widget.

The way it was implemented was to check if the suggestions list was open, and
if open then suppress any tag creation. But this leads to scenarios in which
tags should be created but didn't. For eg: suppose user was typing in some text,
planned to hit tab to loose focus and create a tag and in the mean time the
autocomplete suggestion list pops up. So when the widget looses focus the tag
won't be created.

A sollution for this issue is to check if any autocomplete list row is currently
active at the time of loose focus. when a user is browsing through the tags,
rows of autocomplete would be set active, and this is a better indicator rather
than to check if suggestion box is open. This would ensure prevention of
accidental additions of tags, as there would be exisiting active rows of
the suggestion list. And if the suggestion list pops up while loosing focus,
there would be no active rows of suggestion list and would allow tag creation.