### PR TITLE
Remove regular expression that was causing wrong behaviour

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -251,7 +251,7 @@
                             event.which == $.ui.keyCode.SPACE &&
                             that.options.allowSpaces !== true &&
                             (
-                                $.trim(that.tagInput.val()).replace( /^s*/, '' ).charAt(0) != '"' ||
+                                $.trim(that.tagInput.val()).charAt(0) != '"' ||
                                 (
                                     $.trim(that.tagInput.val()).charAt(0) == '"' &&
                                     $.trim(that.tagInput.val()).charAt($.trim(that.tagInput.val()).length - 1) == '"' &&


### PR DESCRIPTION
Tags can be created when the user selects comma, enter or tab key.
In this situations, there are some checks done, one of them is removing
starting "s" from entered text and then evaluate if the first character is a
quote("). Since the plugin needs to check only if the first character from
the text is a quote(") and not remove any other letters, I removed the replace
function call.