### PR TITLE
Check tagLimit with autocomplete

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -153,7 +153,9 @@
 
             if (this.options.showAutocompleteOnFocus) {
                 this.tagInput.focus(function(event, ui) {
-                    that._showAutocomplete();
+                	if(that.options.tagLimit == null || that._tags().length < that.options.tagLimit){          	
+                		that._showAutocomplete();
+                	}
                 });
 
                 if (typeof this.options.autocomplete.minLength === 'undefined') {
@@ -527,7 +529,9 @@
             });
 
             if (this.options.showAutocompleteOnFocus && !duringInitialization) {
-                setTimeout(function () { that._showAutocomplete(); }, 0);
+            	if(this.options.tagLimit == null || this._tags().length < this.options.tagLimit){
+            		setTimeout(function () { that._showAutocomplete(); }, 0);
+            	}
             }
         },
 


### PR DESCRIPTION
Added a check on tagLimit in order to prevent the autocomplete window from being shown when the tagLimit is reached and is therefore not possible to add further tags.