### PR TITLE
modifying placeholder so ul.tagit can only have a single one and it occupies 100% width

### DIFF
--- a/css/jquery.tagit.css
+++ b/css/jquery.tagit.css
@@ -3,6 +3,7 @@ ul.tagit {
     overflow: auto;
     margin-left: inherit; /* usually we don't want the regular ul margins. */
     margin-right: inherit;
+    position: relative;
 }
 ul.tagit li {
     display: block;
@@ -66,4 +67,15 @@ ul.tagit input[type="text"] {
     width: inherit;
     background-color: inherit;
     outline: none;
+}
+
+ul.tagit li.tagit-placeholder-content {
+  position: absolute;
+  margin-left: 0px;
+  width: 100%;
+  pointer-events: none;
+}
+
+ul.tagit li.tagit-placeholder-content input[type="text"] {
+  width: 100%;
 }

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -134,7 +134,7 @@
 
             if (this.options.placeholderText) {
                 this.placeHolderElement = $('<li class="tagit-new tagit-placeholder-content" />')
-                    .append($('<input type="text" >').attr("placeholder", this.options.placeholderText));
+                    .append($('<input type="text" tabindex="-1" />').attr("placeholder", this.options.placeholderText));
                 this.tagList.append(this.placeHolderElement);
             }
 

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -133,7 +133,9 @@
             }
 
             if (this.options.placeholderText) {
-                this.tagInput.attr('placeholder', this.options.placeholderText);
+                this.placeHolderElement = $('<li class="tagit-new tagit-placeholder-content" />')
+                    .append($('<input type="text" >').attr("placeholder", this.options.placeholderText));
+                this.tagList.append(this.placeHolderElement);
             }
 
             if (!this.options.autocomplete.source) {
@@ -271,6 +273,8 @@
                             that.createTag(that._cleanedInput());
                         }
                     }
+                }).keyup(function(e){
+                    that._updatePlaceholderState();
                 }).blur(function(e){
                     // Create a tag when the element loses focus.
                     // If autocomplete is enabled and suggestion was clicked, don't add it.
@@ -302,6 +306,8 @@
 
                 this.tagInput.autocomplete('widget').addClass('tagit-autocomplete');
             }
+
+            this._updatePlaceholderState();
         },
 
         destroy: function() {
@@ -436,6 +442,19 @@
             return Boolean($.effects && ($.effects[name] || ($.effects.effect && $.effects.effect[name])));
         },
 
+        _updatePlaceholderState: function() {
+            if(!this.placeHolderElement) {
+                return;
+            }
+
+            if((this.tagInput && this.tagInput.val() !== '') || this._tags().length > 0) {
+                this.placeHolderElement.css("display", "none");
+            }
+            else {
+                this.placeHolderElement.css("display", "block");
+            }
+        },
+
         createTag: function(value, additionalClass, duringInitialization) {
             var that = this;
 
@@ -529,6 +548,8 @@
             if (this.options.showAutocompleteOnFocus && !duringInitialization) {
                 setTimeout(function () { that._showAutocomplete(); }, 0);
             }
+
+            this._updatePlaceholderState();
         },
 
         removeTag: function(tag, animate) {
@@ -567,6 +588,8 @@
                 tag.remove();
                 this._trigger('afterTagRemoved', null, {tag: tag, tagLabel: this.tagLabel(tag)});
             }
+
+            this._updatePlaceholderState();
 
         },
 


### PR DESCRIPTION
Hello guys!

I loved tag-it and I would like to contribute with a little improvement on placeholder.

The previous behaviour was to put the placeholder on each .tagit-new input, so every time the user puts some tag on ul.tagit, the placeholder appears again.

I would like to use it as a placeholder for the whole ul element, something like: "Type your tags here.."

So when the user see the ul.tagit for the first time, the placeholder message is there, but when he starts typing and puts his tags,  the message should not be visible anymore.

Please tell me if there is something else I need to do to help you with anything.

Thank you,

Jonathan
