### PR TITLE
Ability to set a tags like label/value pairs. Advanced server side integration.

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -282,8 +282,15 @@
             // Autocomplete.
             if (this.options.availableTags || this.options.tagSource || this.options.autocomplete.source) {
                 var autocompleteOptions = {
-                    select: function(event, ui) {
-                        that.createTag(ui.item.value);
+                    select: function (event, ui) {
+                        debugger;
+                        if (ui.item.label != undefined) {
+                            that.createTag(ui.item.value, undefined, undefined, ui.item.label);
+                        } else {
+                            that.createTag(ui.item.value);
+                        }
+                        
+                        
                         // Preventing the tag input to be updated with the chosen value.
                         return false;
                     }
@@ -436,7 +443,7 @@
             return Boolean($.effects && ($.effects[name] || ($.effects.effect && $.effects.effect[name])));
         },
 
-        createTag: function(value, additionalClass, duringInitialization) {
+        createTag: function(value, additionalClass, duringInitialization,tagLabel) {
             var that = this;
 
             value = $.trim(value);
@@ -466,8 +473,12 @@
                 this._trigger('onTagLimitExceeded', null, {duringInitialization: duringInitialization});
                 return false;
             }
-
-            var label = $(this.options.onTagClicked ? '<a class="tagit-label"></a>' : '<span class="tagit-label"></span>').text(value);
+            if (tagLabel != undefined) {
+                var label = $(this.options.onTagClicked ? '<a class="tagit-label"></a>' : '<span class="tagit-label"></span>').text(tagLabel);
+            } else {
+                var label = $(this.options.onTagClicked ? '<a class="tagit-label"></a>' : '<span class="tagit-label"></span>').text(value);
+            }
+            
 
             // Create tag.
             var tag = $('<li></li>')
@@ -493,9 +504,14 @@
             }
 
             // Unless options.singleField is set, each tag has a hidden input field inline.
+            //and it will also now see if it is a label or a value
             if (!this.options.singleField) {
-                var escapedValue = label.html();
-                tag.append('<input type="hidden" value="' + escapedValue + '" name="' + this.options.fieldName + '" class="tagit-hidden-field" />');
+                if (tagLabel!= null) {
+                    tag.append('<input type="hidden" value="' + value + '" name="' + this.options.fieldName + '" class="tagit-hidden-field" />');
+                } else {
+                    var escapedValue = label.html();
+                    tag.append('<input type="hidden" value="' + escapedValue + '" name="' + this.options.fieldName + '" class="tagit-hidden-field" />');
+                }
             }
 
             if (this._trigger('beforeTagAdded', null, {

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -282,15 +282,8 @@
             // Autocomplete.
             if (this.options.availableTags || this.options.tagSource || this.options.autocomplete.source) {
                 var autocompleteOptions = {
-                    select: function (event, ui) {
-                        debugger;
-                        if (ui.item.label != undefined) {
-                            that.createTag(ui.item.value, undefined, undefined, ui.item.label);
-                        } else {
-                            that.createTag(ui.item.value);
-                        }
-                        
-                        
+                    select: function(event, ui) {
+                        that.createTag(ui.item.value);
                         // Preventing the tag input to be updated with the chosen value.
                         return false;
                     }
@@ -443,7 +436,7 @@
             return Boolean($.effects && ($.effects[name] || ($.effects.effect && $.effects.effect[name])));
         },
 
-        createTag: function(value, additionalClass, duringInitialization,tagLabel) {
+        createTag: function(value, additionalClass, duringInitialization) {
             var that = this;
 
             value = $.trim(value);
@@ -473,12 +466,8 @@
                 this._trigger('onTagLimitExceeded', null, {duringInitialization: duringInitialization});
                 return false;
             }
-            if (tagLabel != undefined) {
-                var label = $(this.options.onTagClicked ? '<a class="tagit-label"></a>' : '<span class="tagit-label"></span>').text(tagLabel);
-            } else {
-                var label = $(this.options.onTagClicked ? '<a class="tagit-label"></a>' : '<span class="tagit-label"></span>').text(value);
-            }
-            
+
+            var label = $(this.options.onTagClicked ? '<a class="tagit-label"></a>' : '<span class="tagit-label"></span>').text(value);
 
             // Create tag.
             var tag = $('<li></li>')
@@ -504,14 +493,9 @@
             }
 
             // Unless options.singleField is set, each tag has a hidden input field inline.
-            //and it will also now see if it is a label or a value
             if (!this.options.singleField) {
-                if (tagLabel!= null) {
-                    tag.append('<input type="hidden" value="' + value + '" name="' + this.options.fieldName + '" class="tagit-hidden-field" />');
-                } else {
-                    var escapedValue = label.html();
-                    tag.append('<input type="hidden" value="' + escapedValue + '" name="' + this.options.fieldName + '" class="tagit-hidden-field" />');
-                }
+                var escapedValue = label.html();
+                tag.append('<input type="hidden" value="' + escapedValue + '" name="' + this.options.fieldName + '" class="tagit-hidden-field" />');
             }
 
             if (this._trigger('beforeTagAdded', null, {


### PR DESCRIPTION
Hello,  @aehlke !
My team want to commit some changes on master branch and help you with a maintainance a little bit. We can discuss changes if it is something wrong.
Here is the issues that can be closed after this commits: #80 #350 #285 #266 #269 #160 #70
1. Added @value component@ to tags. It creates a new input as a value. Also it uses a new option @valueFieldName@. It was done for a server side better integration.
2. Create Tag now can handle a @data@(object) instead of a @value@ (array or primitive). 
3. if you provide a single input option + you return a label/value array from server, the value is saved in value attribute of input. if new value is added it will be added as string.TODO: store a label|value pair.
4. if you return ONLY a label array from server and single input is false, the @label@ and @value@ inputs has the same value. 5)If we add new input and single input is false, the @label@ and @value@ inputs has the same value.
5. Allows predefined values from markdown.