### PR TITLE
Support double quote in name of tag.

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -494,8 +494,11 @@
 
             // Unless options.singleField is set, each tag has a hidden input field inline.
             if (!this.options.singleField) {
-                var escapedValue = label.html();
-                tag.append('<input type="hidden" value="' + escapedValue + '" name="' + this.options.fieldName + '" class="tagit-hidden-field" />');
+                var escapedValue = label.text();
+                var hiddenField = $('<input type="hidden" class="tagit-hidden-field" />');
+                hiddenField.val(escapedValue);
+                hiddenField.attr('name', this.options.fieldName);
+                tag.append(hiddenField);
             }
 
             if (this._trigger('beforeTagAdded', null, {


### PR DESCRIPTION
I updated createTag function to make this function to support double quote ("") and ampersand("&") in the name of tag.