### PR TITLE
Fixed .andSelf() deprecated issue

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -121,7 +121,11 @@
                 this.options.singleFieldNode = this.element;
                 this.element.addClass('tagit-hidden-field');
             } else {
-                this.tagList = this.element.find('ul, ol').andSelf().last();
+                if ($.isFunction($.fn.andSelf)) {
+                    this.tagList = this.element.find('ul, ol').andSelf().last();
+                } else {
+                    this.tagList = this.element.find('ul, ol').addBack().last();
+                }
             }
 
             this.tagInput = $('<input type="text" />').addClass('ui-widget-content');


### PR DESCRIPTION
.andSelf() was deprecated in jQuery 1.8 and removed in 3.0
.addBack() should be used instead.