### PR TITLE
Replace andSelf with addBack for jQuery 3 compatibility

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -121,7 +121,7 @@
                 this.options.singleFieldNode = this.element;
                 this.element.addClass('tagit-hidden-field');
             } else {
-                this.tagList = this.element.find('ul, ol').andSelf().last();
+                this.tagList = this.element.find('ul, ol').addBack().last();
             }
 
             this.tagInput = $('<input type="text" />').addClass('ui-widget-content');


### PR DESCRIPTION
Replace andSelf with addBack in unobtrusive for jQuery 3 compatibility.
The method andSelf was deprecated back in version 1.8 of jQuery and instead used as an alias for addBack.