### PR TITLE
Replaced .andSelf with .andBack

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -121,7 +121,7 @@
                 this.options.singleFieldNode = this.element;
                 this.element.addClass('tagit-hidden-field');
             } else {
-                this.tagList = this.element.find('ul, ol').andSelf().last();
+                this.tagList = this.element.find('ul, ol').addBack().last();
             }
 
             this.tagInput = $('<input type="text" />').addClass('ui-widget-content');


### PR DESCRIPTION
The .andSelf() method was deprecated in jQuery 1.8 and now removed in 3.0 in favor of the .addBack() method, which does a better job of explaining what it does and also accepts an optional selector to filter what is added back.