### PR TITLE
docs: Fix simple typo, unneccesary -> unnecessary

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -48,7 +48,7 @@
             // Shows autocomplete before the user even types anything.
             showAutocompleteOnFocus: false,
 
-            // When enabled, quotes are unneccesary for inputting multi-word tags.
+            // When enabled, quotes are unnecessary for inputting multi-word tags.
             allowSpaces: false,
 
             // The below options are for using a single field instead of several


### PR DESCRIPTION
There is a small typo in js/tag-it.js.

Should read `unnecessary` rather than `unneccesary`.

