### PR TITLE
fix: setting tabindex attr when the value is 0

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -128,9 +128,9 @@
 
             if (this.options.readOnly) this.tagInput.attr('disabled', 'disabled');
 
-            if (this.options.tabIndex) {
-                this.tagInput.attr('tabindex', this.options.tabIndex);
-            }
+			if (null != this.options.tabIndex) {
+				this.tagInput.attr('tabIndex', this.options.tabIndex);
+			}
 
             if (this.options.placeholderText) {
                 this.tagInput.attr('placeholder', this.options.placeholderText);


### PR DESCRIPTION
```js
$(#customselector).tagit({
tabIndex: 0
});
```
This should set `tabindex="0", since `0` is a valid value for setting tabindex when it's meant to be keyboard accessible but not manually overriding tab order