### PR TITLE
Keyboard accessibility

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -129,7 +129,7 @@
             if (this.options.readOnly) this.tagInput.attr('disabled', 'disabled');
 
 			if (null != this.options.tabIndex) {
-				this.tagInput.attr('tabIndex', this.options.tabIndex);
+				this.tagInput.attr('tabindex', this.options.tabIndex);
 			}
 
             if (this.options.placeholderText) {

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -492,6 +492,17 @@
                 tag.append(removeTag);
             }
 
+			// user should be able to remove tags via keyboard navigating with tab when tabindex is set
+			if (null != this.options.tabIndex) {
+				removeTag.attr("tabindex", this.options.tabIndex);
+				removeTag.keypress(function(e) {
+					if (e.which === $.ui.keyCode.ENTER || e.which === $.ui.keyCode.SPACE) {
+						that.removeTag(tag);
+						that.tagInput.focus();  // after removing the tag, set focus back to input
+					}
+				});
+			}
+
             // Unless options.singleField is set, each tag has a hidden input field inline.
             if (!this.options.singleField) {
                 var escapedValue = label.html();

--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -128,9 +128,9 @@
 
             if (this.options.readOnly) this.tagInput.attr('disabled', 'disabled');
 
-            if (this.options.tabIndex) {
-                this.tagInput.attr('tabindex', this.options.tabIndex);
-            }
+			if (null != this.options.tabIndex) {
+				this.tagInput.attr('tabIndex', this.options.tabIndex);
+			}
 
             if (this.options.placeholderText) {
                 this.tagInput.attr('placeholder', this.options.placeholderText);


### PR DESCRIPTION
Upon setting tabIndex option:
- enable keyboard navigation upon tags
- ability to remove tags via keyboard

NOTE: this PR is further improvement of PR #433 