### PR TITLE
Update Homepage and License links

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -5,10 +5,10 @@
 *
 * Copyright 2011, Levy Carneiro Jr.
 * Released under the MIT license.
-* http://aehlke.github.com/tag-it/LICENSE
+* https://github.com/aehlke/tag-it/blob/master/LICENSE
 *
 * Homepage:
-*   http://aehlke.github.com/tag-it/
+*   https://github.com/aehlke/tag-it
 *
 * Authors:
 *   Levy Carneiro Jr.


### PR DESCRIPTION
Both the homepage and license links were not working, which have been updated in this PR.

